### PR TITLE
[Feat] 프로젝트 cors 설정 추가

### DIFF
--- a/src/main/java/org/idiotsdalcheon/emblemeleven/config/WebConfig.java
+++ b/src/main/java/org/idiotsdalcheon/emblemeleven/config/WebConfig.java
@@ -1,0 +1,19 @@
+package org.idiotsdalcheon.emblemeleven.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE, PATCH");
+    }
+}

--- a/src/main/java/org/idiotsdalcheon/emblemeleven/game/dto/PlayerDto.java
+++ b/src/main/java/org/idiotsdalcheon/emblemeleven/game/dto/PlayerDto.java
@@ -10,5 +10,5 @@ import java.util.List;
 public class PlayerDto {
     private String playerName;
     private String playerUrl;
-    private List<String> clubName;
+    private List<String> emblemURL;
 }

--- a/src/main/java/org/idiotsdalcheon/emblemeleven/game/service/PlayerServiceImpl.java
+++ b/src/main/java/org/idiotsdalcheon/emblemeleven/game/service/PlayerServiceImpl.java
@@ -38,7 +38,7 @@ public class PlayerServiceImpl implements PlayerService {
 
                     List<String> clubList = player.getPlayerClubs().stream()
                             .sorted(Comparator.comparing(PlayerClub::getOrder, Comparator.nullsLast(Comparator.naturalOrder())))
-                            .map(pc -> pc.getClub().getName())
+                            .map(pc -> pc.getClub().getEmblemUrl())
                             .collect(Collectors.toList());
 
                     return new PlayerDto(playerName, playerUrl, clubList);


### PR DESCRIPTION
### ✏️ 작업 개요
오리진이 다른 곳에서의 resource 요청을 위한 cors 설정 추가

### ⛳ 작업 분류
- [x] cors 설정을 위한 config 설정

### 🔨 작업 상세 내용
1. cors 설정을 위해 허용할 origin들을 설정해두어야합니다. 현재는 프론트가 배포되어 있지 않으며 프로젝트 초기 단계이기도 하고 보안적으로 중요한 요소가 없기에 일단은 모든 origin을 허용하게 설정해두었습니다. 추후 프로젝트가 진행됨에 따라 오리진을 전체에서 저희가 사용하는 오리진으로 바꾸어둘 예정입니다.

### 💡 생각해볼 문제
- 냉무