### PR TITLE
[Feat] player 저장 api 개발

### DIFF
--- a/src/main/java/org/idiotsdalcheon/emblemeleven/game/controller/PlayerController.java
+++ b/src/main/java/org/idiotsdalcheon/emblemeleven/game/controller/PlayerController.java
@@ -27,9 +27,9 @@ public class PlayerController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/playes")
-    public ResponseEntity<?> savePlayers(@RequestBody PlayerSaveRequest playerSaveRequest){
-        ResponseEntity<?> response = playerService.savePlayer(playerSaveRequest);
+    @PostMapping("")
+    public ResponseEntity<String> savePlayers(@RequestBody PlayerSaveRequest playerSaveRequest){
+        ResponseEntity<String> response = playerService.savePlayer(playerSaveRequest);
         return response;
     }
 }

--- a/src/main/java/org/idiotsdalcheon/emblemeleven/game/controller/PlayerController.java
+++ b/src/main/java/org/idiotsdalcheon/emblemeleven/game/controller/PlayerController.java
@@ -2,9 +2,12 @@ package org.idiotsdalcheon.emblemeleven.game.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.idiotsdalcheon.emblemeleven.game.dto.PlayerInfoResponse;
+import org.idiotsdalcheon.emblemeleven.game.dto.PlayerSaveRequest;
 import org.idiotsdalcheon.emblemeleven.game.service.PlayerService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -22,5 +25,11 @@ public class PlayerController {
 
         PlayerInfoResponse response = playerService.getRandomPlayerInfo(cnt);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/playes")
+    public ResponseEntity<?> savePlayers(@RequestBody PlayerSaveRequest playerSaveRequest){
+        ResponseEntity<?> response = playerService.savePlayer(playerSaveRequest);
+        return response;
     }
 }

--- a/src/main/java/org/idiotsdalcheon/emblemeleven/game/dao/ClubRepository.java
+++ b/src/main/java/org/idiotsdalcheon/emblemeleven/game/dao/ClubRepository.java
@@ -3,5 +3,8 @@ package org.idiotsdalcheon.emblemeleven.game.dao;
 import org.idiotsdalcheon.emblemeleven.game.domain.Club;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ClubRepository extends JpaRepository<Club, Long>  {
+    Optional<Club> findByName(String name);
 }

--- a/src/main/java/org/idiotsdalcheon/emblemeleven/game/dto/ClubDto.java
+++ b/src/main/java/org/idiotsdalcheon/emblemeleven/game/dto/ClubDto.java
@@ -1,0 +1,12 @@
+package org.idiotsdalcheon.emblemeleven.game.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ClubDto {
+    private String clubName;
+    private String emblemUrl;
+    private int order;
+}

--- a/src/main/java/org/idiotsdalcheon/emblemeleven/game/dto/PlayerSaveRequest.java
+++ b/src/main/java/org/idiotsdalcheon/emblemeleven/game/dto/PlayerSaveRequest.java
@@ -1,0 +1,14 @@
+package org.idiotsdalcheon.emblemeleven.game.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class PlayerSaveRequest {
+    private String playerName;
+    private String playerUrl;
+    private List<ClubDto> clubs;
+}

--- a/src/main/java/org/idiotsdalcheon/emblemeleven/game/service/PlayerService.java
+++ b/src/main/java/org/idiotsdalcheon/emblemeleven/game/service/PlayerService.java
@@ -7,5 +7,5 @@ import org.springframework.http.ResponseEntity;
 public interface PlayerService {
     public PlayerInfoResponse getRandomPlayerInfo(int cnt);
 
-    public ResponseEntity<?> savePlayer(PlayerSaveRequest playerRequestDto);
+    public ResponseEntity<String> savePlayer(PlayerSaveRequest playerRequestDto);
 }

--- a/src/main/java/org/idiotsdalcheon/emblemeleven/game/service/PlayerService.java
+++ b/src/main/java/org/idiotsdalcheon/emblemeleven/game/service/PlayerService.java
@@ -1,7 +1,11 @@
 package org.idiotsdalcheon.emblemeleven.game.service;
 
 import org.idiotsdalcheon.emblemeleven.game.dto.PlayerInfoResponse;
+import org.idiotsdalcheon.emblemeleven.game.dto.PlayerSaveRequest;
+import org.springframework.http.ResponseEntity;
 
 public interface PlayerService {
     public PlayerInfoResponse getRandomPlayerInfo(int cnt);
+
+    public ResponseEntity<?> savePlayer(PlayerSaveRequest playerRequestDto);
 }

--- a/src/main/java/org/idiotsdalcheon/emblemeleven/game/service/PlayerServiceImpl.java
+++ b/src/main/java/org/idiotsdalcheon/emblemeleven/game/service/PlayerServiceImpl.java
@@ -30,7 +30,7 @@ public class PlayerServiceImpl implements PlayerService {
 
     @Override
     @Transactional
-    public ResponseEntity<?> savePlayer(PlayerSaveRequest playerSaveRequest) {
+    public ResponseEntity<String> savePlayer(PlayerSaveRequest playerSaveRequest) {
         // player 저장
         Player player = Player.builder()
                 .name(playerSaveRequest.getPlayerName())

--- a/src/main/java/org/idiotsdalcheon/emblemeleven/game/service/PlayerServiceImpl.java
+++ b/src/main/java/org/idiotsdalcheon/emblemeleven/game/service/PlayerServiceImpl.java
@@ -1,13 +1,20 @@
 package org.idiotsdalcheon.emblemeleven.game.service;
 
 import lombok.RequiredArgsConstructor;
+import org.idiotsdalcheon.emblemeleven.game.dao.ClubRepository;
+import org.idiotsdalcheon.emblemeleven.game.dao.PlayerClubRepository;
 import org.idiotsdalcheon.emblemeleven.game.dao.PlayerRepository;
+import org.idiotsdalcheon.emblemeleven.game.domain.Club;
 import org.idiotsdalcheon.emblemeleven.game.domain.Player;
 import org.idiotsdalcheon.emblemeleven.game.domain.PlayerClub;
+import org.idiotsdalcheon.emblemeleven.game.dto.ClubDto;
 import org.idiotsdalcheon.emblemeleven.game.dto.PlayerDto;
 import org.idiotsdalcheon.emblemeleven.game.dto.PlayerInfoResponse;
+import org.idiotsdalcheon.emblemeleven.game.dto.PlayerSaveRequest;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
@@ -18,6 +25,40 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PlayerServiceImpl implements PlayerService {
     private final PlayerRepository playerRepository;
+    private final ClubRepository clubRepository;
+    private final PlayerClubRepository playerClubRepository;
+
+    @Override
+    @Transactional
+    public ResponseEntity<?> savePlayer(PlayerSaveRequest playerSaveRequest) {
+        // player 저장
+        Player player = Player.builder()
+                .name(playerSaveRequest.getPlayerName())
+                .photoUrl(playerSaveRequest.getPlayerUrl())
+                .build();
+        player = playerRepository.save(player);
+
+        // club 저장
+        for(ClubDto clubDto : playerSaveRequest.getClubs()){
+            Club club = clubRepository.findByName(clubDto.getClubName())
+                    .orElseGet(() -> clubRepository.save(
+                            Club.builder()
+                                    .name(clubDto.getClubName())
+                                    .emblemUrl(clubDto.getEmblemUrl())
+                                    .build()
+                    ));
+
+            // PlayerClub 저장
+            PlayerClub playerClub = PlayerClub.builder()
+                    .player(player)
+                    .club(club)
+                    .order(clubDto.getOrder())
+                    .build();
+            playerClubRepository.save(playerClub);
+        }
+
+        return ResponseEntity.ok("저장 완료");
+    }
 
     @Override
     public PlayerInfoResponse getRandomPlayerInfo(int cnt) {

--- a/src/test/java/org/idiotsdalcheon/emblemeleven/game/controller/PlayerControllerTest.java
+++ b/src/test/java/org/idiotsdalcheon/emblemeleven/game/controller/PlayerControllerTest.java
@@ -1,30 +1,41 @@
 package org.idiotsdalcheon.emblemeleven.game.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.idiotsdalcheon.emblemeleven.game.dao.ClubRepository;
 import org.idiotsdalcheon.emblemeleven.game.dao.PlayerClubRepository;
 import org.idiotsdalcheon.emblemeleven.game.dao.PlayerRepository;
 import org.idiotsdalcheon.emblemeleven.game.domain.Club;
 import org.idiotsdalcheon.emblemeleven.game.domain.Player;
 import org.idiotsdalcheon.emblemeleven.game.domain.PlayerClub;
+import org.idiotsdalcheon.emblemeleven.game.dto.ClubDto;
+import org.idiotsdalcheon.emblemeleven.game.dto.PlayerSaveRequest;
 import org.idiotsdalcheon.emblemeleven.game.service.PlayerService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.util.Arrays;
-
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 class PlayerControllerTest {
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Autowired
     private PlayerService playerService;
@@ -147,6 +158,33 @@ class PlayerControllerTest {
         // when
         mockMvc.perform(get("/players/random?cnt=7"))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 플레이어_저장_api_테스트() throws Exception {
+        // given
+        PlayerSaveRequest request = new PlayerSaveRequest(
+                "손흥민",
+                "https://example.com/photo.png",
+                Arrays.asList(
+                        new ClubDto("토트넘", "1234", 2),
+                        new ClubDto("레버쿠젠", "5678", 1)
+                )
+        );
+
+        // when
+//        when(playerService.savePlayer(any(PlayerSaveRequest.class)))
+//                .thenReturn(ResponseEntity.ok("저장 완료"));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/players")
+                        .content(objectMapper.writeValueAsBytes(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string("저장 완료"));
+
+        // then
+        //verify(playerService, times(1)).savePlayer(any(PlayerSaveRequest.class));
     }
 
 }


### PR DESCRIPTION
### ✏️ 작업 개요
앞으로 추가될 문제들을 위해 선수와 클럽 저장 기능 개발

### ⛳ 작업 분류
- [x] 비즈니스 로직 개발 및 테스트 코드 통과
- [x] controller 개발 및 테스트 코드 통과

### 🔨 작업 상세 내용
1. 비즈니스 레이어에서 선수 데이터를 추가하기 위한 로직을 구현하였습니다. 여기서 클럽과 선수는 다대다 관계를 가지기에 중간 테이블을 두어 해당 테이블에서 외래키를 가지고 관리하게 구성하였습니다. 
2. 선수들마다 거쳐간 클럽의 순서가 저장되어야 하기에 중간 테이블에서 순서를 저장하는 컬럼을  추가하여 저장하게 구성하였으며 저장시 이미 클럽에 대한 데이터가 있다면 해당 클럽을 외래키로 지정하고 만약 클럽이 저장되어 있지 않다면 클럽 테이블에 데이터를 저장하여 연결하게 구성하였습니다.
3. 테스트의 경우 단위 테스트와 통합 테스트를 거치게 구성하였습니다. MockMvc를 이용하여 Mock객체를 최대한 활용하여 구성하였습니다.

### 💡 생각해볼 문제
- 이번 기회에 최대한 테스트 코드를 작성을 하며 테스트에 대해 공부를 하고 있습니다. 아래의 공식 문서와 다른 블로그들을 참고하여 공부 중에 있습니다.
https://spring.io/guides/gs/testing-web
https://adjh54.tistory.com/347